### PR TITLE
ハンズオン後半でBlueGreenDeployを試すので，そのときに使うリソースの追加と修正をコメントアウトで残した

### DIFF
--- a/go_api/manifests/deployment.yml
+++ b/go_api/manifests/deployment.yml
@@ -30,10 +30,8 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /hello
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          # terminationGracePeriodSeconds: 30
+      #   lifecycle:
+      #     preStop:
+      #       exec:
+      #         command: ["/bin/sh", "-c", "sleep 20"]
+      # terminationGracePeriodSeconds: 30

--- a/go_api/manifests/pod-disruption-budget.yml
+++ b/go_api/manifests/pod-disruption-budget.yml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: eks-handson-go
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: eks-handson-go


### PR DESCRIPTION
* livenessProbeはreadinessProbeと同時に入れていると，どうもserviceインする前にヘルスチェックが通ってしまうか何かで予期せぬリクエストを受け取ってリクエストを落とすことがあったので，削除した
* lifecycleでgraceful-shutdownの設定を追加した
* pod-disruption-budgetを追加した